### PR TITLE
Fix framealpha of prettyplot to be a value between 0-1

### DIFF
--- a/src/uncertainpy/plotting/prettyplot/prettyplot.py
+++ b/src/uncertainpy/plotting/prettyplot/prettyplot.py
@@ -39,7 +39,7 @@ Set legend options.
         "legend.fontsize": fontsize,
         "legend.handlelength": 2.2,
         "legend.borderpad": 0.5,
-        "legend.framealpha": 2,
+        "legend.framealpha": 1,
         "legend.fancybox": True
     }
     plt.rcParams.update(params)


### PR DESCRIPTION
Saving plots using 
```
plotting = uncertainpy.plotting.PlotUncertainty(filename=..., figureformat='.svg)
plotting.plot_all()
```
crashed with `ValueError: RGBA values should be within 0-1 range` using Matplotlib version 3.1.3. This was because of `framealpha=2` in `prettyplot.py`. This PR fixes the issue by setting alpha to one.
